### PR TITLE
fix(formulario): forms view adjusted

### DIFF
--- a/client/src/Views/Formulario/Formulario.jsx
+++ b/client/src/Views/Formulario/Formulario.jsx
@@ -53,12 +53,12 @@ function Formulario() {
   return (
     <div className="conecte-se">
         <div className="container">
-                <div className="formulario" id="conecte-text">
-                  <UnderlineTitle title="Conecte com outra Empresa Júnior"/>
-                    <Formstext justify="right" Contacttext={paragrafo1}/>
-                  <Formstext justify="right" Contacttext={paragrafo2}/>
-                  <Formstext justify="right" Contacttext={paragrafo3}/>
-                </div>
+              <UnderlineTitle title="Conecte com outra Empresa Júnior"/>
+              <div className="formulario" id="conecte-text">
+                <Formstext justify="right" Contacttext={paragrafo1}/>
+                <Formstext justify="right" Contacttext={paragrafo2}/>
+                <Formstext justify="right" Contacttext={paragrafo3}/>
+              </div>"
             <div className="formulario" id="forms-info">
               <form className='Form' onSubmit={sendEmail}> 
                 <input className="form-field"


### PR DESCRIPTION
## What I did

- Ajustei o título da view

| Mockup | Real |
|--------|------|
| <img width="632" alt="Screen Shot 2021-03-16 at 14 03 32" src="https://user-images.githubusercontent.com/41218597/111349982-671f0280-8660-11eb-96d7-a4bdb35e3e52.png"> | <img width="632" alt="Screen Shot 2021-03-16 at 14 03 32" src="https://user-images.githubusercontent.com/41218597/111350975-705c9f00-8661-11eb-8ace-a119a41c8a4a.png"> |


## How to test

1. Open the terminal and go to the folder of this project

1. In terminal:
   1. `git checkout develop`
   1. `git pull`
   1. `git checkout <branch name>`
   1. `git pull origin <branch name>`
   1. `yarn start`
   1. `yarn develop`

1. In your browser go to http://localhost:3000

1. Check if the component looks just like the mockup in deferent screen sizes 

1. Read the changed files section on GitHub 

1. Test the things that you think are worth testing, even the ones that are not in this description 

